### PR TITLE
rename Increment to SimpleSend

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -69,9 +69,10 @@ func (graphite *Graphite) SendMetric(metric Metric) {
 	graphite.sendMetric(metric)
 }
 
-// The Increment method increments an arbitrary metric on the remote graphite host
-func (graphite *Graphite) Increment(stat string) error {
-	metric := Metric{Name: stat, Value: "1", Timestamp: time.Now().Unix()}
+// The SimpleSend method can be used to just pass a metric name and value and
+// have it be sent to the Graphite host with the current timestamp
+func (graphite *Graphite) SimpleSend(stat string, value string) error {
+	metric := Metric{Name: stat, Value: value, Timestamp: time.Now().Unix()}
 	err := graphite.sendMetric(metric)
 	if err != nil {
 		return err

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -27,7 +27,7 @@ func TestNewGraphite(t *testing.T) {
 //	if err != nil {
 //		t.Error(err)
 //	}
-//	err = gh.Increment("stats.test.metric11")
+//	err = gh.SimpleSend("stats.test.metric11", "1")
 //	if err != nil {
 //		t.Error(err)
 //	}


### PR DESCRIPTION
I renamed the `Increment` method to `SimpleSend`. This now also provides an easy way to update a metric without having to create a struct and it also requires a value parameter to send, since 1 is rarely what you actually want to send to Graphite.

Background to this is that Graphite doesn't have any notion of "incrementing" a value. A stored value will always be overwritten when you send another value with the same timestamp. There is nothing getting incremented or added on the Graphite side. For this to work you would need some pre-aggregation proxy like StatsD or the [carbon aggregator](https://graphite.readthedocs.org/en/latest/carbon-daemons.html#carbon-aggregator-py)
