### PR TITLE
Send multiple metrics in a batch

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -58,34 +58,58 @@ func (graphite *Graphite) SendMetric(metric Metric) error {
 	if metric.Timestamp == 0 {
 		metric.Timestamp = time.Now().Unix()
 	}
+	metrics := make([]Metric, 1)
+	metrics[0] = metric
 
-	return graphite.sendMetric(metric)
+	return graphite.sendMetrics(metrics)
+}
+
+// Given a slice of Metrics, the SendMetrics method sends the metrics, as a
+// batch, to the Graphite connection that the method is called upon
+func (graphite *Graphite) SendMetrics(metrics []Metric) error {
+	for _, metric := range metrics {
+		if metric.Timestamp == 0 {
+			metric.Timestamp = time.Now().Unix()
+		}
+	}
+
+	return graphite.sendMetrics(metrics)
+}
+
+// sendMetrics is an internal function that is used to write to the TCP
+// connection in order to communicate metrics to the remote Graphite host
+func (graphite *Graphite) sendMetrics(metrics []Metric) error {
+	zeroed_metric := Metric{} // ignore unintialized metrics
+	if !graphite.IsNop() {
+		buf := bytes.NewBufferString("")
+		for _, metric := range metrics {
+			if metric == zeroed_metric {
+				continue // ignore unintialized metrics
+			}
+			buf.WriteString(fmt.Sprintf("%s %s %d\n", metric.Name, metric.Value, metric.Timestamp))
+		}
+		_, err := graphite.conn.Write(buf.Bytes())
+		fmt.Print("Sent msg:", buf.String(), "'")
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, metric := range metrics {
+			log.Printf("Graphite: %s\n", metric)
+		}
+	}
+	return nil
 }
 
 // The SimpleSend method can be used to just pass a metric name and value and
 // have it be sent to the Graphite host with the current timestamp
 func (graphite *Graphite) SimpleSend(stat string, value string) error {
-	metric := NewMetric(stat, value, time.Now().Unix())
-	err := graphite.sendMetric(metric)
+	metrics := make([]Metric, 1)
+	metrics[0] = NewMetric(stat, value, time.Now().Unix())
+	err := graphite.sendMetrics(metrics)
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-// sendMetric is an internal function that is used to write to the TCP
-// connection in order to communicate a metric to the remote Graphite host
-func (graphite *Graphite) sendMetric(metric Metric) error {
-	if !graphite.IsNop() {
-		buf := bytes.NewBufferString(fmt.Sprintf("%s %s %d\n", metric.Name, metric.Value, metric.Timestamp))
-		_, err := graphite.conn.Write(buf.Bytes())
-		if err != nil {
-			return err
-		}
-	} else {
-		log.Printf("Graphite: %s\n", metric)
-	}
-
 	return nil
 }
 

--- a/graphite.go
+++ b/graphite.go
@@ -27,9 +27,8 @@ const defaultTimeout = 5
 func (graphite *Graphite) IsNop() bool {
 	if graphite.nop {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 // Given a Graphite struct, Connect populates the Graphite.conn field with an


### PR DESCRIPTION
Adding a SendMetrics method to batch up metrics delivery. This is to save a tiny bit of network overhead (carbon is UDP so we're not saving handshake overhead, just filling out packets better) but also to move batching logic into the library and out of folks own code.