### PR TITLE
host, port vs. address string

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -13,7 +13,7 @@ import (
 type Graphite struct {
 	Address string
 	Timeout time.Duration
-	Prefix	string
+	Prefix  string
 	conn    net.Conn
 	nop     bool
 }
@@ -135,6 +135,18 @@ func NewGraphite(host string, port int) (*Graphite, error) {
 	return Graphite, nil
 }
 
+// NewGraphiteHost is a factory method that's used to create a new Graphite
+// connection given an address string understood by net.Dial
+func NewGraphiteFromAddress(address string) (*Graphite, error) {
+	Graphite := &Graphite{Address: address}
+	err := Graphite.Connect()
+	if err != nil {
+		return nil, err
+	}
+
+	return Graphite, nil
+}
+
 // NewGraphiteNop is a factory method that returns a Graphite struct but will
 // not actually try to send any packets to a remote host and, instead, will just
 // log. This is useful if you want to use Graphite in a project but don't want
@@ -142,6 +154,15 @@ func NewGraphite(host string, port int) (*Graphite, error) {
 func NewGraphiteNop(host string, port int) *Graphite {
 	address := fmt.Sprintf("%s:%d", host, port)
 
+	graphiteNop := &Graphite{Address: address, nop: true}
+	return graphiteNop
+}
+
+// NewGraphiteNop is a factory method that returns a Graphite struct but will
+// not actually try to send any packets to a remote host and, instead, will just
+// log. This is useful if you want to use Graphite in a project but don't want
+// to make Graphite a requirement for the project.
+func NewGraphiteNopFromAdress(address string) *Graphite {
 	graphiteNop := &Graphite{Address: address, nop: true}
 	return graphiteNop
 }

--- a/graphite.go
+++ b/graphite.go
@@ -11,8 +11,7 @@ import (
 // Graphite is a struct that defines the relevant properties of a graphite
 // connection
 type Graphite struct {
-	Host    string
-	Port    int
+	Address string
 	Timeout time.Duration
 	Prefix	string
 	conn    net.Conn
@@ -39,13 +38,11 @@ func (graphite *Graphite) Connect() error {
 			graphite.conn.Close()
 		}
 
-		address := fmt.Sprintf("%s:%d", graphite.Host, graphite.Port)
-
 		if graphite.Timeout == 0 {
 			graphite.Timeout = defaultTimeout * time.Second
 		}
 
-		conn, err := net.DialTimeout("tcp", address, graphite.Timeout)
+		conn, err := net.DialTimeout("tcp", graphite.Address, graphite.Timeout)
 		if err != nil {
 			return err
 		}
@@ -127,7 +124,9 @@ func (graphite *Graphite) SimpleSend(stat string, value string) error {
 // NewGraphiteHost is a factory method that's used to create a new Graphite
 // connection given a hostname and a port number
 func NewGraphite(host string, port int) (*Graphite, error) {
-	Graphite := &Graphite{Host: host, Port: port}
+	address := fmt.Sprintf("%s:%d", host, port)
+
+	Graphite := &Graphite{Address: address}
 	err := Graphite.Connect()
 	if err != nil {
 		return nil, err
@@ -141,6 +140,8 @@ func NewGraphite(host string, port int) (*Graphite, error) {
 // log. This is useful if you want to use Graphite in a project but don't want
 // to make Graphite a requirement for the project.
 func NewGraphiteNop(host string, port int) *Graphite {
-	graphiteNop := &Graphite{Host: host, Port: port, nop: true}
+	address := fmt.Sprintf("%s:%d", host, port)
+
+	graphiteNop := &Graphite{Address: address, nop: true}
 	return graphiteNop
 }

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -1,6 +1,7 @@
 package graphite
 
 import (
+	"fmt"
 	"net"
 	"testing"
 )
@@ -8,9 +9,21 @@ import (
 // Change these to be your own graphite server if you so please
 var graphiteHost = "carbon.hostedgraphite.com"
 var graphitePort = 2003
+var graphiteAddress = fmt.Sprintf("%s:%d", graphiteHost, graphitePort)
 
 func TestNewGraphite(t *testing.T) {
 	gh, err := NewGraphite(graphiteHost, graphitePort)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if _, ok := gh.conn.(*net.TCPConn); !ok {
+		t.Error("GraphiteHost.conn is not a TCP connection")
+	}
+}
+
+func TestNewGraphiteFromAddress(t *testing.T) {
+	gh, err := NewGraphiteFromAddress(graphiteAddress)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This updates the struct to store the remote host as an address string and not a combination of host and port.
In some cases the graphite host:port maybe given as a single string which would have to be split up in order to create the graphite struct. This is very ugly because net.Dial wants to have the address string anyway and the seperated host port strings are not used anywhere in the code.

This of course might break code which changes the struct values directly but code that uses the factory methods will still work.
