### PR TITLE
Fix UDP send

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -98,12 +98,19 @@ func (graphite *Graphite) sendMetrics(metrics []Metric) error {
 			} else {
 				metric_name = metric.Name
 			}
+			if graphite.Protocol == "udp" {
+				bufString := bytes.NewBufferString(fmt.Sprintf("%s %s %d\n", metric_name, metric.Value, metric.Timestamp))
+				graphite.conn.Write(bufString.Bytes())
+				continue
+			}
 			buf.WriteString(fmt.Sprintf("%s %s %d\n", metric_name, metric.Value, metric.Timestamp))
 		}
-		_, err := graphite.conn.Write(buf.Bytes())
-		//fmt.Print("Sent msg:", buf.String(), "'")
-		if err != nil {
-			return err
+		if graphite.Protocol == "tcp" {
+			_, err := graphite.conn.Write(buf.Bytes())
+			//fmt.Print("Sent msg:", buf.String(), "'")
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		for _, metric := range metrics {


### PR DESCRIPTION
Sends via udp is limited to max datagram size.
If we tries to send lot of metrics, we trigger error:

`write udp 127.0.0.1:49188->127.0.0.1:2003: write: message too long`

This patchset implements sending via udp one metric per one datagram; it not so costly, because of UDP.